### PR TITLE
minor link bug fix

### DIFF
--- a/src/codec/Makefile.am
+++ b/src/codec/Makefile.am
@@ -9,3 +9,5 @@ lib_LTLIBRARIES = libosmocodec.la
 
 libosmocodec_la_SOURCES = gsm610.c gsm620.c gsm660.c gsm690.c
 libosmocodec_la_LDFLAGS = -version-info $(LIBVERSION) -no-undefined
+
+libosmocodec_la_LIBADD = $(top_builddir)/src/libosmocore.la


### PR DESCRIPTION
I had the following link problem on MacOSX. 

```
Making all in src/codec
  CC       gsm610.lo
  CC       gsm620.lo
  CC       gsm660.lo
  CC       gsm690.lo
  CCLD     libosmocodec.la
Undefined symbols for architecture x86_64:
  "_bitvec_get_bit_pos", referenced from:
      _osmo_fr_check_sid in gsm610.o
  "_bitvec_get_uint", referenced from:
      _osmo_hr_check_sid in gsm620.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [libosmocodec.la] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```

This pull request fixes it, I don't know why top library wasn't linked - shouldn't be working before. 