### PR TITLE
Fix libosmousb target name

### DIFF
--- a/src/usb/Makefile.am
+++ b/src/usb/Makefile.am
@@ -12,8 +12,8 @@ if ENABLE_LIBUSB
 lib_LTLIBRARIES = libosmousb.la
 
 libosmousb_la_SOURCES = osmo_libusb.c
-libosmosim_la_LDFLAGS = -version-info $(LIBVERSION)
-libosmosim_la_LIBADD = \
+libosmousb_la_LDFLAGS = -version-info $(LIBVERSION)
+libosmousb_la_LIBADD = \
 	$(top_builddir)/src/libosmocore.la \
 	$(TALLOC_LIBS) \
 	$(LIBUSB_LIBS)

--- a/src/usb/Makefile.am
+++ b/src/usb/Makefile.am
@@ -12,7 +12,7 @@ if ENABLE_LIBUSB
 lib_LTLIBRARIES = libosmousb.la
 
 libosmousb_la_SOURCES = osmo_libusb.c
-libosmousb_la_LDFLAGS = -version-info $(LIBVERSION)
+libosmousb_la_LDFLAGS = -version-info $(LIBVERSION) -no-undefined
 libosmousb_la_LIBADD = \
 	$(top_builddir)/src/libosmocore.la \
 	$(TALLOC_LIBS) \


### PR DESCRIPTION
... and add " -no-undefined" to LDFLAGS. Simple fixes that allow the build to succeed for me on OSX in MacPorts, but are not OS-specific.